### PR TITLE
Use Gravatar hash URL for profile images

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -29,7 +29,7 @@ params:
     subtitle: >
       M.Sc. in Computer Science, +10 years experience in Web development, Software Architect and 
       Lead Data Scientist and Machine Learning Engineer in Ecentria Group, a medium-size US e-commerce.
-    imageUrl: "https://gravatar.com/userimage/34319433/0e83d173c7c89f3eff94693f0c08e3fa.jpeg?size=2048"
+    imageUrl: "https://www.gravatar.com/avatar/b2151ae9f3afd05e042047fbd0462499?s=2048"
     imageTitle: "Dmitrijs Balabka"
     imageWidth: 200
     imageHeight: 200
@@ -40,7 +40,7 @@ params:
     #     url: "https://github.com/"
 
   description: Geek's blog about Software Engineering, Artificial Intelligence and science
-  profilePicture: https://gravatar.com/userimage/34319433/0e83d173c7c89f3eff94693f0c08e3fa.jpeg?size=2048
+  profilePicture: https://www.gravatar.com/avatar/b2151ae9f3afd05e042047fbd0462499?s=2048
 
   socialIcons:
     - name: Linkedin


### PR DESCRIPTION
### Motivation
- Use a canonical Gravatar avatar URL derived from the account email hash so the site profile image is consistent and served from Gravatar rather than a custom `userimage` path.

### Description
- Replaced `params.profileMode.imageUrl` in `hugo.yaml` with `https://www.gravatar.com/avatar/b2151ae9f3afd05e042047fbd0462499?s=2048` (MD5 of `dmitry.balabka@gmail.com`).
- Replaced `params.profilePicture` in `hugo.yaml` with the same Gravatar avatar URL so both profile image settings remain consistent.

### Testing
- Ran `hugo --gc --minify` to validate the build, but the command failed because `hugo` is not installed in this environment (test failed).
- Ran a Playwright screenshot script targeting `http://127.0.0.1:1313`, but the script failed due to no local server responding (`net::ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a50f7a1c83339890104c7975d532)